### PR TITLE
Add ability to sign JWS' during intruder attack

### DIFF
--- a/src/main/java/burp/JWTEditorExtension.java
+++ b/src/main/java/burp/JWTEditorExtension.java
@@ -25,6 +25,7 @@ import com.blackberry.jwteditor.view.editor.ResponseEditorView;
 import com.blackberry.jwteditor.view.rsta.RstaFactory;
 
 import java.awt.*;
+import java.util.Optional;
 
 import static burp.api.montoya.core.BurpSuiteEdition.COMMUNITY_EDITION;
 import static burp.api.montoya.core.BurpSuiteEdition.PROFESSIONAL;
@@ -105,7 +106,7 @@ public class JWTEditorExtension implements BurpExtension {
         );
 
         Intruder intruder = api.intruder();
-        intruder.registerPayloadProcessor(new JWSPayloadProcessor(burpConfig.intruderConfig()));
+        intruder.registerPayloadProcessor(new JWSPayloadProcessor(burpConfig.intruderConfig(), Optional.of(api.logging()), Optional.of(keysModel)));
 
         if (api.burpSuite().version().edition() != COMMUNITY_EDITION) {
             api.scanner().registerInsertionPointProvider(new JWSHeaderInsertionPointProvider(burpConfig.scannerConfig()));

--- a/src/main/java/burp/intruder/JWSPayloadProcessor.java
+++ b/src/main/java/burp/intruder/JWSPayloadProcessor.java
@@ -4,9 +4,14 @@ import burp.api.montoya.core.ByteArray;
 import burp.api.montoya.intruder.PayloadData;
 import burp.api.montoya.intruder.PayloadProcessingResult;
 import burp.api.montoya.intruder.PayloadProcessor;
+import burp.api.montoya.logging.Logging;
+
+import com.blackberry.jwteditor.exceptions.SigningException;
 import com.blackberry.jwteditor.model.jose.JOSEObject;
 import com.blackberry.jwteditor.model.jose.JWS;
 import com.blackberry.jwteditor.model.jose.JWSFactory;
+import com.blackberry.jwteditor.model.keys.Key;
+import com.blackberry.jwteditor.model.keys.KeysModel;
 import com.nimbusds.jose.util.Base64URL;
 import org.json.JSONObject;
 
@@ -16,10 +21,14 @@ import static burp.intruder.FuzzLocation.PAYLOAD;
 import static com.blackberry.jwteditor.model.jose.JOSEObjectFinder.parseJOSEObject;
 
 public class JWSPayloadProcessor implements PayloadProcessor {
+    Optional<Logging> logging;
     private final IntruderConfig intruderConfig;
+    private final Optional<KeysModel> keysModel;
 
-    public JWSPayloadProcessor(IntruderConfig intruderConfig) {
+    public JWSPayloadProcessor(IntruderConfig intruderConfig, Optional<Logging> logging, Optional<KeysModel> keysModel) {
+        this.logging = logging;
         this.intruderConfig = intruderConfig;
+        this.keysModel = keysModel;
     }
 
     @Override
@@ -43,7 +52,7 @@ public class JWSPayloadProcessor implements PayloadProcessor {
                         ? Base64URL.encode(targetJson.toString())
                         : jws.getEncodedPayload();
 
-                JWS updatedJws = JWSFactory.jwsFromParts(updatedHeader, updatedPayload, jws.getEncodedSignature());
+                JWS updatedJws = this.createJWS(updatedHeader, updatedPayload, jws.getEncodedSignature());
                 baseValue = ByteArray.byteArray(updatedJws.serialize());
             }
         }
@@ -54,5 +63,39 @@ public class JWSPayloadProcessor implements PayloadProcessor {
     @Override
     public String displayName() {
         return "JWS payload processor";
+    }
+
+    private Optional<Key> loadKey() {
+        if (keysModel.isPresent()) {
+            String keyId = intruderConfig.signingKeyId();
+            // only try to load key if the input value is non-empty
+            if (keyId.trim().length() > 0) {
+                Key key = keysModel.get().getKey(intruderConfig.signingKeyId());
+                if (key != null) {
+                    return Optional.of(key);
+                } else {
+                    this.logging.ifPresent(log -> log.logToError("Key with ID " + intruderConfig.signingKeyId() + " not found"));
+                }
+            }
+        } else {
+            this.logging.ifPresent(log -> log.logToOutput("No keysModel available. Will not be able to sign JWS"));
+        }
+
+        return Optional.empty();
+    }
+
+    // Creates a JWS object from the given attributes. Signs the JWS if possible (i.e., available key selected in Intruder settings)
+    private JWS createJWS(Base64URL header, Base64URL payload, Base64URL originalSignature) {
+        return this.loadKey().flatMap(key -> {
+            Optional<JWS> result = Optional.empty();
+
+            try {
+                result = Optional.of(JWSFactory.sign(key, key.getSigningAlgorithms()[0], header, payload));
+            } catch (SigningException ex) {
+                this.logging.ifPresent(log -> log.logToError("Failed to sign JWS: " + ex));
+            }
+
+            return result;
+        }).orElseGet(() -> JWSFactory.jwsFromParts(header, payload, originalSignature));
     }
 }

--- a/src/main/java/burp/intruder/JWSPayloadProcessor.java
+++ b/src/main/java/burp/intruder/JWSPayloadProcessor.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import static burp.intruder.FuzzLocation.PAYLOAD;
 import static com.blackberry.jwteditor.model.jose.JOSEObjectFinder.parseJOSEObject;
+import static com.blackberry.jwteditor.utils.Constants.INTRUDER_NO_SIGNING_KEY_ID_LABEL;
 
 public class JWSPayloadProcessor implements PayloadProcessor {
     Optional<Logging> logging;
@@ -69,7 +70,7 @@ public class JWSPayloadProcessor implements PayloadProcessor {
         if (keysModel.isPresent()) {
             String keyId = intruderConfig.signingKeyId();
             // only try to load key if the input value is non-empty
-            if (keyId.trim().length() > 0) {
+            if (keyId.trim().length() > 0 && keyId != INTRUDER_NO_SIGNING_KEY_ID_LABEL) {
                 Key key = keysModel.get().getKey(intruderConfig.signingKeyId());
                 if (key != null) {
                     return Optional.of(key);

--- a/src/main/java/com/blackberry/jwteditor/model/keys/KeysModel.java
+++ b/src/main/java/com/blackberry/jwteditor/model/keys/KeysModel.java
@@ -19,11 +19,11 @@ limitations under the License.
 package com.blackberry.jwteditor.model.keys;
 
 import com.blackberry.jwteditor.exceptions.UnsupportedKeyException;
-import com.blackberry.jwteditor.model.keys.KeysModelListener.InertKeyModelListener;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,12 +37,12 @@ import static java.util.Collections.unmodifiableCollection;
 public class KeysModel {
     private final Map<String, Key> keys;
     private final Object lock;
-    
-    private KeysModelListener modelListener;
+
+    private List<KeysModelListener> modelListeners;
 
     public KeysModel() {
         this.keys = new LinkedHashMap<>();
-        this.modelListener = new InertKeyModelListener();
+        this.modelListeners = new ArrayList<KeysModelListener>();
         this.lock = new Object();
     }
 
@@ -53,7 +53,7 @@ public class KeysModel {
     }
 
     public void addKeyModelListener(KeysModelListener modelListener) {
-        this.modelListener = modelListener;
+        this.modelListeners.add(modelListener);
     }
 
     /**
@@ -131,8 +131,10 @@ public class KeysModel {
             oldKey = keys.put(key.getID(), key);
         }
 
-        modelListener.notifyKeyDeleted(oldKey);
-        modelListener.notifyKeyInserted(key);
+        for (KeysModelListener modelListener: this.modelListeners) {
+            modelListener.notifyKeyDeleted(oldKey);
+            modelListener.notifyKeyInserted(key);
+        }
     }
 
     private int findIndexOfKeyWithId(String id) {
@@ -163,7 +165,9 @@ public class KeysModel {
         }
 
         if (rowIndex >= 0) {
-            modelListener.notifyKeyDeleted(rowIndex);
+            for (KeysModelListener modelListener: this.modelListeners) {
+                modelListener.notifyKeyDeleted(rowIndex);
+            }
         }
     }
 

--- a/src/main/java/com/blackberry/jwteditor/utils/Constants.java
+++ b/src/main/java/com/blackberry/jwteditor/utils/Constants.java
@@ -1,0 +1,5 @@
+package com.blackberry.jwteditor.utils;
+
+public class Constants {
+    public static String INTRUDER_NO_SIGNING_KEY_ID_LABEL = "<do not sign (keep original signature)>";
+}

--- a/src/main/java/com/blackberry/jwteditor/view/SuiteView.java
+++ b/src/main/java/com/blackberry/jwteditor/view/SuiteView.java
@@ -94,6 +94,6 @@ public class SuiteView {
                 keysModel,
                 rstaFactory
         );
-        configView = new ConfigView(burpConfig, userInterface, isProVersion);
+        configView = new ConfigView(burpConfig, userInterface, isProVersion, keysModel);
     }
 }

--- a/src/main/java/com/blackberry/jwteditor/view/config/ConfigView.form
+++ b/src/main/java/com/blackberry/jwteditor/view/config/ConfigView.form
@@ -215,19 +215,18 @@
                 <properties/>
               </component>
 
-              <component id="ccb95" class="javax.swing.JLabel">
+              <component id="f80c6" class="javax.swing.JLabel">
                 <constraints>
-                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
+                  <horizontalTextPosition value="2"/>
                   <text resource-bundle="strings" key="intruder_signing_key_id"/>
                 </properties>
               </component>
-              <component id="52033" class="javax.swing.JTextField" binding="intruderSigningKeyId">
+              <component id="1892c" class="javax.swing.JComboBox" binding="comboBoxIntruderSigningKeyId">
                 <constraints>
-                  <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                    <preferred-size width="150" height="-1"/>
-                  </grid>
+                  <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties/>
               </component>

--- a/src/main/java/com/blackberry/jwteditor/view/config/ConfigView.form
+++ b/src/main/java/com/blackberry/jwteditor/view/config/ConfigView.form
@@ -157,7 +157,7 @@
           </grid>
         </children>
       </grid>
-      <grid id="4b0a1" binding="intruderPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="10">
+      <grid id="4b0a1" binding="intruderPanel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="10">
         <margin top="15" left="5" bottom="15" right="5"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
@@ -173,10 +173,10 @@
               <text value="Intruder"/>
             </properties>
           </component>
-          <grid id="23fd" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="23fd" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="2" column="0" row-span="2" col-span="2" vsize-policy="3" hsize-policy="3" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="3" col-span="2" vsize-policy="3" hsize-policy="3" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="empty">
@@ -214,6 +214,24 @@
                 </constraints>
                 <properties/>
               </component>
+
+              <component id="ccb95" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text resource-bundle="strings" key="intruder_signing_key_id"/>
+                </properties>
+              </component>
+              <component id="52033" class="javax.swing.JTextField" binding="intruderSigningKeyId">
+                <constraints>
+                  <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties/>
+              </component>
+
               <component id="cd314" class="javax.swing.JLabel" binding="spacerLabel">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>

--- a/src/main/java/com/blackberry/jwteditor/view/config/ConfigView.java
+++ b/src/main/java/com/blackberry/jwteditor/view/config/ConfigView.java
@@ -25,12 +25,19 @@ import burp.intruder.IntruderConfig;
 import burp.proxy.HighlightColor;
 import burp.proxy.ProxyConfig;
 import burp.scanner.ScannerConfig;
+
+import com.blackberry.jwteditor.model.keys.KeysModel;
 import com.blackberry.jwteditor.view.utils.DocumentAdapter;
+import static com.blackberry.jwteditor.utils.Constants.INTRUDER_NO_SIGNING_KEY_ID_LABEL;
 
 import javax.swing.*;
+
+import org.apache.commons.lang3.ArrayUtils;
+
 import java.awt.*;
 
 import static java.awt.Font.BOLD;
+
 
 /**
  *  Config panel
@@ -43,7 +50,7 @@ public class ConfigView {
     private JLabel labelHighlightJWT;
     private JTextField intruderParameterName;
     private JComboBox comboBoxPayloadPosition;
-    private JTextField intruderSigningKeyId;
+    private JComboBox comboBoxIntruderSigningKeyId;
     private JCheckBox checkBoxHeaderInsertionPoint;
     private JTextField scannerParameterName;
     private JPanel proxyPanel;
@@ -53,7 +60,7 @@ public class ConfigView {
     private JPanel intruderPanel;
     private JLabel spacerLabel;
 
-    public ConfigView(BurpConfig burpConfig, UserInterface userInterface, boolean isProVersion) {
+    public ConfigView(BurpConfig burpConfig, UserInterface userInterface, boolean isProVersion, KeysModel keysModel) {
         ProxyConfig proxyConfig = burpConfig.proxyConfig();
 
         checkBoxHighlightJWT.setSelected(proxyConfig.highlightJWT());
@@ -78,11 +85,12 @@ public class ConfigView {
         comboBoxPayloadPosition.setSelectedItem(intruderConfig.fuzzLocation());
         comboBoxPayloadPosition.addActionListener(e -> intruderConfig.setFuzzLocation((FuzzLocation) comboBoxPayloadPosition.getSelectedItem()));
 
-        // TODO: Make dropdown menu
-        intruderSigningKeyId.setText(intruderConfig.signingKeyId()); // 2
-        intruderSigningKeyId.getDocument().addDocumentListener(
-            new DocumentAdapter(e -> intruderConfig.setSigningKeyId(intruderSigningKeyId.getText()))
-        );
+        String[] noSigningKey = {INTRUDER_NO_SIGNING_KEY_ID_LABEL};
+        String[] signingKeyIds = keysModel.getSigningKeys().stream().map(key -> key.getID()).toArray(String[]::new);
+        String[] items = ArrayUtils.addAll(noSigningKey, signingKeyIds);
+        comboBoxIntruderSigningKeyId.setModel(new DefaultComboBoxModel<>(items));
+        comboBoxIntruderSigningKeyId.setSelectedItem(intruderConfig.signingKeyId());
+        comboBoxIntruderSigningKeyId.addActionListener(e -> intruderConfig.setSigningKeyId((String) comboBoxIntruderSigningKeyId.getSelectedItem()));
 
         ScannerConfig scannerConfig = burpConfig.scannerConfig();
 

--- a/src/main/java/com/blackberry/jwteditor/view/config/ConfigView.java
+++ b/src/main/java/com/blackberry/jwteditor/view/config/ConfigView.java
@@ -43,6 +43,7 @@ public class ConfigView {
     private JLabel labelHighlightJWT;
     private JTextField intruderParameterName;
     private JComboBox comboBoxPayloadPosition;
+    private JTextField intruderSigningKeyId;
     private JCheckBox checkBoxHeaderInsertionPoint;
     private JTextField scannerParameterName;
     private JPanel proxyPanel;
@@ -76,6 +77,12 @@ public class ConfigView {
         comboBoxPayloadPosition.setModel(new DefaultComboBoxModel<>(FuzzLocation.values()));
         comboBoxPayloadPosition.setSelectedItem(intruderConfig.fuzzLocation());
         comboBoxPayloadPosition.addActionListener(e -> intruderConfig.setFuzzLocation((FuzzLocation) comboBoxPayloadPosition.getSelectedItem()));
+
+        // TODO: Make dropdown menu
+        intruderSigningKeyId.setText(intruderConfig.signingKeyId()); // 2
+        intruderSigningKeyId.getDocument().addDocumentListener(
+            new DocumentAdapter(e -> intruderConfig.setSigningKeyId(intruderSigningKeyId.getText()))
+        );
 
         ScannerConfig scannerConfig = burpConfig.scannerConfig();
 

--- a/src/main/resources/strings.properties
+++ b/src/main/resources/strings.properties
@@ -115,6 +115,7 @@ proxy_config_proxy_listener_enabled=Highlight JWTs within HTTP and WebSocket mes
 proxy_config_highlight_color=Highlight color:
 intruder_payload_processing_location=Payload Position:
 intruder_payload_processing_parameter_name=Parameter Name:
+intruder_signing_key_id=Signing Key ID:
 empty_key_signing_dialog_title=Empty Key Signing Dialog
 empty_key_signing_algorithm=Algorithm
 psychic_signature_signing_dialog_title=Psychic Signature Signing Dialog

--- a/src/test/java/burp/intruder/JWTPayloadProcessorTest.java
+++ b/src/test/java/burp/intruder/JWTPayloadProcessorTest.java
@@ -8,10 +8,14 @@ import burp.api.montoya.internal.ObjectFactoryLocator;
 import burp.api.montoya.intruder.FakePayloadProcessingResult;
 import burp.api.montoya.intruder.PayloadData;
 import burp.api.montoya.intruder.PayloadProcessingResult;
+import burp.api.montoya.logging.Logging;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.stubbing.Answer;
+
+import com.blackberry.jwteditor.model.keys.KeysModel;
 
 import static burp.api.montoya.intruder.FakePayloadData.payloadData;
 import static burp.api.montoya.intruder.PayloadProcessingAction.USE_PAYLOAD;
@@ -21,6 +25,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 
 @ExtendWith(MontoyaExtension.class)
 class JWTPayloadProcessorTest {
@@ -39,7 +45,9 @@ class JWTPayloadProcessorTest {
     void givenBaseValueNotJWS_whenPayloadProcessed_thenPayloadLeftUnchanged() {
         String baseValue = "isogeny";
         PayloadData payloadData = payloadData().withBaseValue(baseValue).build();
-        JWSPayloadProcessor processor = new JWSPayloadProcessor(intruderConfig("role", PAYLOAD));
+        Optional<Logging> emptyLogging = Optional.empty();
+        Optional<KeysModel> emptyKeysModel = Optional.empty();
+        JWSPayloadProcessor processor = new JWSPayloadProcessor(intruderConfig("role", PAYLOAD), emptyLogging, emptyKeysModel);
 
         PayloadProcessingResult result = processor.processPayload(payloadData);
 
@@ -51,7 +59,9 @@ class JWTPayloadProcessorTest {
     void givenBaseValueJWSAndFuzzParameterNotPresent_whenPayloadProcessed_thenPayloadLeftUnchanged() {
         String baseValue = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
         PayloadData payloadData = payloadData().withBaseValue(baseValue).build();
-        JWSPayloadProcessor processor = new JWSPayloadProcessor(intruderConfig("role", PAYLOAD));
+        Optional<Logging> emptyLogging = Optional.empty();
+        Optional<KeysModel> emptyKeysModel = Optional.empty();
+        JWSPayloadProcessor processor = new JWSPayloadProcessor(intruderConfig("role", PAYLOAD), emptyLogging, emptyKeysModel);
 
         PayloadProcessingResult result = processor.processPayload(payloadData);
 
@@ -63,7 +73,9 @@ class JWTPayloadProcessorTest {
     void givenBaseValueJWSAndFuzzParameterPresentInWrongContext_whenPayloadProcessed_thenPayloadLeftUnchanged() {
         String baseValue = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
         PayloadData payloadData = payloadData().withBaseValue(baseValue).build();
-        JWSPayloadProcessor processor = new JWSPayloadProcessor(intruderConfig("alg", PAYLOAD));
+        Optional<Logging> emptyLogging = Optional.empty();
+        Optional<KeysModel> emptyKeysModel = Optional.empty();
+        JWSPayloadProcessor processor = new JWSPayloadProcessor(intruderConfig("alg", PAYLOAD), emptyLogging, emptyKeysModel);
 
         PayloadProcessingResult result = processor.processPayload(payloadData);
 
@@ -75,7 +87,9 @@ class JWTPayloadProcessorTest {
     void givenBaseValueJWSAndFuzzParameterPresentInHeader_whenPayloadProcessed_thenPayloadModified() {
         String baseValue = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
         PayloadData payloadData = payloadData().withBaseValue(baseValue).withCurrentPayload("RS256").build();
-        JWSPayloadProcessor processor = new JWSPayloadProcessor(intruderConfig("alg", HEADER));
+        Optional<Logging> emptyLogging = Optional.empty();
+        Optional<KeysModel> emptyKeysModel = Optional.empty();
+        JWSPayloadProcessor processor = new JWSPayloadProcessor(intruderConfig("alg", HEADER), emptyLogging, emptyKeysModel);
 
         PayloadProcessingResult result = processor.processPayload(payloadData);
 
@@ -87,7 +101,9 @@ class JWTPayloadProcessorTest {
     void givenBaseValueJWSAndFuzzParameterPresentInPayload_whenPayloadProcessed_thenPayloadModified() {
         String baseValue = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
         PayloadData payloadData = payloadData().withBaseValue(baseValue).withCurrentPayload("emanon").build();
-        JWSPayloadProcessor processor = new JWSPayloadProcessor(intruderConfig("name", PAYLOAD));
+        Optional<Logging> emptyLogging = Optional.empty();
+        Optional<KeysModel> emptyKeysModel = Optional.empty();
+        JWSPayloadProcessor processor = new JWSPayloadProcessor(intruderConfig("name", PAYLOAD), emptyLogging, emptyKeysModel);
 
         PayloadProcessingResult result = processor.processPayload(payloadData);
 


### PR DESCRIPTION
This PR adds another Intruder setting to select a configured signing key. If one is selected when `processPayload` is called, the JWS is signed with the key. If any error happens, we fall back to the current behavior of using the original signature.

Feel free to give feedback, or make adjustments to the code, as I have not coded in Java in years.