### PR TITLE
Convert TimeClaim strings to the JVM time zone

### DIFF
--- a/src/main/java/com/blackberry/jwteditor/model/jose/Information.java
+++ b/src/main/java/com/blackberry/jwteditor/model/jose/Information.java
@@ -18,13 +18,15 @@ limitations under the License.
 
 package com.blackberry.jwteditor.model.jose;
 
+import java.time.ZoneId;
+
 public record Information(String text, boolean isWarning) {
 
-    public static Information from(TimeClaim timeClaim) {
+    public static Information from(TimeClaim timeClaim, ZoneId timeZoneId) {
         StringBuilder sb = new StringBuilder(timeClaim.type().toString()).append(" - ");
 
         if (timeClaim.hasDate()) {
-            sb.append(timeClaim.date());
+            sb.append(timeClaim.date(timeZoneId));
         } else {
             sb.append("invalid value: ").append(timeClaim.value());
         }

--- a/src/main/java/com/blackberry/jwteditor/model/jose/JOSEObject.java
+++ b/src/main/java/com/blackberry/jwteditor/model/jose/JOSEObject.java
@@ -20,6 +20,7 @@ package com.blackberry.jwteditor.model.jose;
 
 import com.nimbusds.jose.util.Base64URL;
 
+import java.time.ZoneId;
 import java.util.List;
 
 /**
@@ -42,5 +43,5 @@ public abstract class JOSEObject {
      */
     public abstract String serialize();
 
-    public abstract List<Information> information();
+    public abstract List<Information> information(ZoneId timeZoneId);
 }

--- a/src/main/java/com/blackberry/jwteditor/model/jose/JWE.java
+++ b/src/main/java/com/blackberry/jwteditor/model/jose/JWE.java
@@ -28,6 +28,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import java.security.Provider;
 import java.security.Security;
 import java.text.ParseException;
+import java.time.ZoneId;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -69,7 +70,7 @@ public class JWE extends JOSEObject {
     }
 
     @Override
-    public List<Information> information() {
+    public List<Information> information(ZoneId timeZoneId) {
         return emptyList();
     }
 

--- a/src/main/java/com/blackberry/jwteditor/model/jose/JWS.java
+++ b/src/main/java/com/blackberry/jwteditor/model/jose/JWS.java
@@ -26,6 +26,7 @@ import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.util.Base64URL;
 
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.blackberry.jwteditor.model.jose.JWSVerifierFactory.verifierFor;
@@ -68,9 +69,9 @@ public class JWS extends JOSEObject {
     }
 
     @Override
-    public List<Information> information() {
+    public List<Information> information(ZoneId timeZoneId) {
         return claims.timeClaims().stream()
-                .map(Information::from)
+                .map(timeClaim -> Information.from(timeClaim, timeZoneId))
                 .toList();
     }
 

--- a/src/main/java/com/blackberry/jwteditor/model/jose/MutableJOSEObject.java
+++ b/src/main/java/com/blackberry/jwteditor/model/jose/MutableJOSEObject.java
@@ -18,6 +18,7 @@ limitations under the License.
 
 package com.blackberry.jwteditor.model.jose;
 
+import java.time.ZoneId;
 import java.util.List;
 
 /**
@@ -74,7 +75,7 @@ public class MutableJOSEObject {
         return original;
     }
 
-    public List<Information> information() {
-        return modified.information();
+    public List<Information> information(ZoneId timeZoneId) {
+        return modified.information(timeZoneId);
     }
 }

--- a/src/main/java/com/blackberry/jwteditor/model/jose/TimeClaim.java
+++ b/src/main/java/com/blackberry/jwteditor/model/jose/TimeClaim.java
@@ -18,17 +18,18 @@ limitations under the License.
 
 package com.blackberry.jwteditor.model.jose;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import static java.util.Locale.US;
 
 public record TimeClaim(TimeClaimType type, String value, ZonedDateTime dateTime) {
-    private static final String DATE_TIME_PATTERN = "EEE MMM dd yyyy HH:mm:ss";
+    private static final String DATE_TIME_PATTERN = "EEE MMM dd yyyy HH:mm:ss O";
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_PATTERN).withLocale(US);
 
-    public String date() {
-        return dateTime == null ? "" : FORMATTER.format(dateTime);
+    public String date(ZoneId timeZoneId) {
+        return dateTime == null ? "" : FORMATTER.withZone(timeZoneId).format(dateTime);
     }
 
     public boolean hasDate() {

--- a/src/main/java/com/blackberry/jwteditor/presenter/EditorPresenter.java
+++ b/src/main/java/com/blackberry/jwteditor/presenter/EditorPresenter.java
@@ -39,8 +39,10 @@ import com.nimbusds.jose.util.Base64URL;
 import org.json.JSONException;
 
 import java.text.ParseException;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
+import java.util.TimeZone;
 
 import static com.blackberry.jwteditor.model.jose.ClaimsType.JSON;
 import static com.blackberry.jwteditor.model.jose.ClaimsType.TEXT;
@@ -53,6 +55,7 @@ import static com.blackberry.jwteditor.view.dialog.operations.SigningPanel.Mode.
 import static com.blackberry.jwteditor.view.dialog.operations.SigningPanel.Mode.NORMAL;
 
 public class EditorPresenter {
+    private final static ZoneId JVM_DEFAULT_TIME_ZONE_ID = TimeZone.getDefault().toZoneId();
 
     private final KeysRepository keysRepository;
     private final TokenRepository tokenRepository;
@@ -387,7 +390,7 @@ public class EditorPresenter {
         //Highlight the serialized text as changed if it differs from the original, and the change wasn't triggered by onSelectionChanging
         view.setSerialized(joseObject.serialize(), mutableJoseObject.changed() && !selectionChanging);
 
-        view.setInformation(mutableJoseObject.information());
+        view.setInformation(mutableJoseObject.information(JVM_DEFAULT_TIME_ZONE_ID));
     }
 
     /**

--- a/src/test/java/com/blackberry/jwteditor/model/jose/JWSInformationTest.java
+++ b/src/test/java/com/blackberry/jwteditor/model/jose/JWSInformationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.text.ParseException;
+import java.time.ZoneId;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,7 +37,7 @@ class JWSInformationTest {
     void givenJWSWithNoTimeClaims_thenInformationIsEmpty() throws ParseException {
         JWS jws = JWSFactory.parse("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJUZXN0In0.WVLalefVZ5Rj991Cjgh0qBjKSIQaqC_CgN3b-30GKpQ");
 
-        assertThat(jws.information()).isEmpty();
+        assertThat(jws.information(ZoneId.of("UTC"))).isEmpty();
     }
 
     @ParameterizedTest
@@ -47,17 +48,17 @@ class JWSInformationTest {
     void givenJWSWithExpTimeClaims_thenInformationCorrect(String data) throws ParseException {
         JWS jws = JWSFactory.parse(data);
 
-        Information information = jws.information().getFirst();
+        Information information = jws.information(ZoneId.of("UTC")).getFirst();
 
-        assertThat(information.text()).isEqualTo("Expiration Time - Mon May 20 2024 21:03:42");
+        assertThat(information.text()).isEqualTo("Expiration Time - Mon May 20 2024 21:03:42 GMT");
         assertThat(information.isWarning()).isTrue();
     }
 
     private static Stream<Arguments> jwsWithValidExpValues() {
         return Stream.of(
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoyMzE2MjM5MDIyfQ.nmCDcUHT-yLgrRG1LKMH9E2FQs2xWcB8CncxoqKdQEQ", "Expiration Time - Tue May 26 2043 07:43:42"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoiMjMxNjIzOTAyMiJ9.kDOLZJTcFVwrSVSDeFK31EIx7Q4e4Ya33iNCk4QZ10c", "Expiration Time - Tue May 26 2043 07:43:42"),
-                arguments("eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoiMjAzNi0xMi0xOVQxNjozOTo1Ny0wODowMCJ9.", "Expiration Time - Fri Dec 19 2036 16:39:57")
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoyMzE2MjM5MDIyfQ.nmCDcUHT-yLgrRG1LKMH9E2FQs2xWcB8CncxoqKdQEQ", "Expiration Time - Tue May 26 2043 07:43:42 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoiMjMxNjIzOTAyMiJ9.kDOLZJTcFVwrSVSDeFK31EIx7Q4e4Ya33iNCk4QZ10c", "Expiration Time - Tue May 26 2043 07:43:42 GMT"),
+                arguments("eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoiMjAzNi0xMi0xOVQxNjozOTo1Ny0wODowMCJ9.", "Expiration Time - Sat Dec 20 2036 00:39:57 GMT")
         );
     }
 
@@ -66,7 +67,7 @@ class JWSInformationTest {
     void givenJWSWithExpTimeClaims_whenExpiryDateInTheFuture_thenInformationCorrect(String data, String expectedText) throws ParseException {
         JWS jws = JWSFactory.parse(data);
 
-        Information information = jws.information().getFirst();
+        Information information = jws.information(ZoneId.of("UTC")).getFirst();
 
         assertThat(information.text()).isEqualTo(expectedText);
         assertThat(information.isWarning()).isFalse();
@@ -85,7 +86,7 @@ class JWSInformationTest {
     void givenJWSWithExpTimeClaims_whenExpiryDateInvalid_thenInformationCorrect(String data, String expectedText) throws ParseException {
         JWS jws = JWSFactory.parse(data);
 
-        Information information = jws.information().getFirst();
+        Information information = jws.information(ZoneId.of("UTC")).getFirst();
 
         assertThat(information.text()).isEqualTo(expectedText);
         assertThat(information.isWarning()).isTrue();
@@ -93,8 +94,8 @@ class JWSInformationTest {
 
     private static Stream<Arguments> jwsWithExpValuesInThePast() {
         return Stream.of(
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJleHAiOjE1MTYyMzkwMjJ9.mVGXFv3OuwtuZPsdaf_oGUYm2uOH-T-JRTDQE1c10q0", "Expiration Time - Thu Jan 18 2018 01:30:22"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJleHAiOjB9.eVVhRMapPD77WuMWIHKBqYw0cjJHC49On-mHEuonYjk", "Expiration Time - Thu Jan 01 1970 00:00:00")
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJleHAiOjE1MTYyMzkwMjJ9.mVGXFv3OuwtuZPsdaf_oGUYm2uOH-T-JRTDQE1c10q0", "Expiration Time - Thu Jan 18 2018 01:30:22 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJleHAiOjB9.eVVhRMapPD77WuMWIHKBqYw0cjJHC49On-mHEuonYjk", "Expiration Time - Thu Jan 01 1970 00:00:00 GMT")
         );
     }
 
@@ -103,7 +104,7 @@ class JWSInformationTest {
     void givenJWSWithExpTimeClaims_whenExpiryDateIsInThePast_thenInformationCorrect(String data, String expectedText) throws ParseException {
         JWS jws = JWSFactory.parse(data);
 
-        Information information = jws.information().getFirst();
+        Information information = jws.information(ZoneId.of("UTC")).getFirst();
 
         assertThat(information.text()).isEqualTo(expectedText);
         assertThat(information.isWarning()).isTrue();
@@ -118,20 +119,20 @@ class JWSInformationTest {
     void givenJWSWithNbfTimeClaims_thenInformationCorrect(String data) throws ParseException {
         JWS jws = JWSFactory.parse(data);
 
-        Information information = jws.information().getFirst();
+        Information information = jws.information(ZoneId.of("UTC")).getFirst();
 
-        assertThat(information.text()).isEqualTo("Not Before - Mon May 20 2024 21:03:42");
+        assertThat(information.text()).isEqualTo("Not Before - Mon May 20 2024 21:03:42 GMT");
         assertThat(information.isWarning()).isFalse();
     }
 
     private static Stream<Arguments> jwsWithValidNbfValues() {
         return Stream.of(
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwibmJmIjoxNzE2MjM5MDIyfQ.mZ_wGwRA0BBp_m6LJOPOBfwMosKrhTf9DbnKZYTzBzg", "Not Before - Mon May 20 2024 21:03:42"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwibmJmIjoiMTcxNjIzOTAyMiJ9.JD7t6jE6sOzuaFi5Lj5e3RhnoRDDWW9QHv_U3bFgEKM", "Not Before - Mon May 20 2024 21:03:42"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJuYmYiOjE1MTYyMzkwMjJ9.1OhNEYnVM64dytXGZ1kj_Z3fV73xGFxWyba52S5r7wc", "Not Before - Thu Jan 18 2018 01:30:22"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJuYmYiOjB9.AqIAHlKSdpcDp7mD6sWsfKCQxI2hyJYsI7Y4Dh6N6pI", "Not Before - Thu Jan 01 1970 00:00:00"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJuYmYiOjE3MjIxNjc0Nzd9.2almhOGrigs8lXH9DLKBkkUCS6r5j7zpJXYsXJN39d4", "Not Before - Sun Jul 28 2024 11:51:17"),
-                arguments("eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwibmJmIjoiMjAyNC0wNS0yMFQyMjowMzo0MiswMTowMCJ9.", "Not Before - Mon May 20 2024 22:03:42")
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwibmJmIjoxNzE2MjM5MDIyfQ.mZ_wGwRA0BBp_m6LJOPOBfwMosKrhTf9DbnKZYTzBzg", "Not Before - Mon May 20 2024 21:03:42 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwibmJmIjoiMTcxNjIzOTAyMiJ9.JD7t6jE6sOzuaFi5Lj5e3RhnoRDDWW9QHv_U3bFgEKM", "Not Before - Mon May 20 2024 21:03:42 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJuYmYiOjE1MTYyMzkwMjJ9.1OhNEYnVM64dytXGZ1kj_Z3fV73xGFxWyba52S5r7wc", "Not Before - Thu Jan 18 2018 01:30:22 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJuYmYiOjB9.AqIAHlKSdpcDp7mD6sWsfKCQxI2hyJYsI7Y4Dh6N6pI", "Not Before - Thu Jan 01 1970 00:00:00 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJuYmYiOjE3MjIxNjc0Nzd9.2almhOGrigs8lXH9DLKBkkUCS6r5j7zpJXYsXJN39d4", "Not Before - Sun Jul 28 2024 11:51:17 GMT"),
+                arguments("eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwibmJmIjoiMjAyNC0wNS0yMFQyMjowMzo0MiswMTowMCJ9.", "Not Before - Mon May 20 2024 21:03:42 GMT")
         );
     }
 
@@ -140,7 +141,7 @@ class JWSInformationTest {
     void givenJWSWithNbfTimeClaims_whenNotBeforeDateInThePast_thenInformationCorrect(String data, String expectedText) throws ParseException {
         JWS jws = JWSFactory.parse(data);
 
-        Information information = jws.information().getFirst();
+        Information information = jws.information(ZoneId.of("UTC")).getFirst();
 
         assertThat(information.text()).isEqualTo(expectedText);
         assertThat(information.isWarning()).isFalse();
@@ -159,7 +160,7 @@ class JWSInformationTest {
     void givenJWSWithNbfTimeClaims_whenNotBeforeDateInvalid_thenInformationCorrect(String data, String expectedText) throws ParseException {
         JWS jws = JWSFactory.parse(data);
 
-        Information information = jws.information().getFirst();
+        Information information = jws.information(ZoneId.of("UTC")).getFirst();
 
         assertThat(information.text()).isEqualTo(expectedText);
         assertThat(information.isWarning()).isTrue();
@@ -167,8 +168,8 @@ class JWSInformationTest {
 
     private static Stream<Arguments> jwsWithFutureNbfValues() {
         return Stream.of(
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJuYmYiOjIzMjIxNjc0Nzd9.cMocfo6ghvuYBqDwZ9GBdfbCnMLsUcZe2GZRuaah0-c", "Not Before - Sun Aug 02 2043 22:31:17"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJuYmYiOjE4MjIxNjc0Nzd9._m-Rhio9DLcVRfWo7S-KIvlTk29QuDgal-tqreN4y4E", "Not Before - Tue Sep 28 2027 21:37:57")
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJuYmYiOjIzMjIxNjc0Nzd9.cMocfo6ghvuYBqDwZ9GBdfbCnMLsUcZe2GZRuaah0-c", "Not Before - Sun Aug 02 2043 22:31:17 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJuYmYiOjE4MjIxNjc0Nzd9._m-Rhio9DLcVRfWo7S-KIvlTk29QuDgal-tqreN4y4E", "Not Before - Tue Sep 28 2027 21:37:57 GMT")
         );
     }
 
@@ -177,7 +178,7 @@ class JWSInformationTest {
     void givenJWSWithNbfTimeClaims_whenNotBeforeDateIsInTheFuture_thenInformationCorrect(String data, String expectedText) throws ParseException {
         JWS jws = JWSFactory.parse(data);
 
-        Information information = jws.information().getFirst();
+        Information information = jws.information(ZoneId.of("UTC")).getFirst();
 
         assertThat(information.text()).isEqualTo(expectedText);
         assertThat(information.isWarning()).isTrue();
@@ -186,8 +187,8 @@ class JWSInformationTest {
 
     private static Stream<Arguments> jwsWithValidIatValues() {
         return Stream.of(
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE3MTYyMzkwMjJ9.y06rqsXv0DMutukwDaUJU0Sf-Ye3qrDkyFpOaj1J08A", "Issued At - Mon May 20 2024 21:03:42"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOiIxNzE2MjM5MDIyIn0.c2Ogr8QeTwopupVPqI56VaovZXE3svug2BI-Trft2EA", "Issued At - Mon May 20 2024 21:03:42")
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE3MTYyMzkwMjJ9.y06rqsXv0DMutukwDaUJU0Sf-Ye3qrDkyFpOaj1J08A", "Issued At - Mon May 20 2024 21:03:42 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOiIxNzE2MjM5MDIyIn0.c2Ogr8QeTwopupVPqI56VaovZXE3svug2BI-Trft2EA", "Issued At - Mon May 20 2024 21:03:42 GMT")
         );
     }
 
@@ -196,7 +197,7 @@ class JWSInformationTest {
     void givenJWSWithIatTimeClaims_thenInformationCorrect(String data, String expectedText) throws ParseException {
         JWS jws = JWSFactory.parse(data);
 
-        Information information = jws.information().getFirst();
+        Information information = jws.information(ZoneId.of("UTC")).getFirst();
 
         assertThat(information.text()).isEqualTo(expectedText);
         assertThat(information.isWarning()).isFalse();
@@ -205,12 +206,12 @@ class JWSInformationTest {
 
     private static Stream<Arguments> jwsWithValidIatDatesInThePast() {
         return Stream.of(
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE3MTYyMzkwMjJ9.y06rqsXv0DMutukwDaUJU0Sf-Ye3qrDkyFpOaj1J08A", "Issued At - Mon May 20 2024 21:03:42"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOiIxNzE2MjM5MDIyIn0.c2Ogr8QeTwopupVPqI56VaovZXE3svug2BI-Trft2EA", "Issued At - Mon May 20 2024 21:03:42"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.hqWGSaFpvbrXkOWc6lrnffhNWR19W_S1YKFBx2arWBk", "Issued At - Thu Jan 18 2018 01:30:22"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjB9.9TaucSjKgR3_gXUlzTGperv3PK9IAXO0ZVbgP9Wx4IY", "Issued At - Thu Jan 01 1970 00:00:00"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE3MjIxNjc0Nzd9.SWmvLUBWE5ddBWvSEWnrHM8W3rfzyYmEQVk6-ywFFgQ", "Issued At - Sun Jul 28 2024 11:51:17"),
-                arguments("eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMjAyNC0wNS0yMFQyMjowMzo0MiswMTowMCJ9.", "Issued At - Mon May 20 2024 22:03:42")
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE3MTYyMzkwMjJ9.y06rqsXv0DMutukwDaUJU0Sf-Ye3qrDkyFpOaj1J08A", "Issued At - Mon May 20 2024 21:03:42 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOiIxNzE2MjM5MDIyIn0.c2Ogr8QeTwopupVPqI56VaovZXE3svug2BI-Trft2EA", "Issued At - Mon May 20 2024 21:03:42 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.hqWGSaFpvbrXkOWc6lrnffhNWR19W_S1YKFBx2arWBk", "Issued At - Thu Jan 18 2018 01:30:22 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjB9.9TaucSjKgR3_gXUlzTGperv3PK9IAXO0ZVbgP9Wx4IY", "Issued At - Thu Jan 01 1970 00:00:00 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE3MjIxNjc0Nzd9.SWmvLUBWE5ddBWvSEWnrHM8W3rfzyYmEQVk6-ywFFgQ", "Issued At - Sun Jul 28 2024 11:51:17 GMT"),
+                arguments("eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoiMjAyNC0wNS0yMFQyMjowMzo0MiswMTowMCJ9.", "Issued At - Mon May 20 2024 21:03:42 GMT")
         );
     }
 
@@ -219,7 +220,7 @@ class JWSInformationTest {
     void givenJWSWithIatTimeClaims_whenIssuedAtDateInThePast_thenInformationCorrect(String data, String expectedText) throws ParseException {
         JWS jws = JWSFactory.parse(data);
 
-        Information information = jws.information().getFirst();
+        Information information = jws.information(ZoneId.of("UTC")).getFirst();
 
         assertThat(information.text()).isEqualTo(expectedText);
         assertThat(information.isWarning()).isFalse();
@@ -238,7 +239,7 @@ class JWSInformationTest {
     void givenJWSWithIatTimeClaims_whenIssuedAtDateInvalid_thenInformationCorrect(String data, String expectedText) throws ParseException {
         JWS jws = JWSFactory.parse(data);
 
-        Information information = jws.information().getFirst();
+        Information information = jws.information(ZoneId.of("UTC")).getFirst();
 
         assertThat(information.text()).isEqualTo(expectedText);
         assertThat(information.isWarning()).isTrue();
@@ -247,8 +248,8 @@ class JWSInformationTest {
 
     private static Stream<Arguments> jwsWithFutureIatDates() {
         return Stream.of(
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjIzMjIxNjc0Nzd9.3UYGoLpdXRhnlai81VFV_iWmW90xnCimcYverY1-Zk4", "Issued At - Sun Aug 02 2043 22:31:17"),
-                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE4MjIxNjc0Nzd9._H-G7WjMbg8IVADVbz1Lsd7I_bGQZBYKPf8S2Q9vxf4", "Issued At - Tue Sep 28 2027 21:37:57")
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjIzMjIxNjc0Nzd9.3UYGoLpdXRhnlai81VFV_iWmW90xnCimcYverY1-Zk4", "Issued At - Sun Aug 02 2043 22:31:17 GMT"),
+                arguments("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE4MjIxNjc0Nzd9._H-G7WjMbg8IVADVbz1Lsd7I_bGQZBYKPf8S2Q9vxf4", "Issued At - Tue Sep 28 2027 21:37:57 GMT")
         );
     }
 
@@ -257,16 +258,41 @@ class JWSInformationTest {
     void givenJWSWithIatTimeClaims_whenIssuedAtDateIsInTheFuture_thenInformationCorrect(String data, String expectedText) throws ParseException {
         JWS jws = JWSFactory.parse(data);
 
-        Information information = jws.information().getFirst();
+        Information information = jws.information(ZoneId.of("UTC")).getFirst();
 
         assertThat(information.text()).isEqualTo(expectedText);
         assertThat(information.isWarning()).isTrue();
+    }
+
+    private static Stream<Arguments> timeZonesAndJWSWithValidExpValues() {
+        return Stream.of(
+                arguments("UTC","eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoyMzE2MjM5MDIyfQ.nmCDcUHT-yLgrRG1LKMH9E2FQs2xWcB8CncxoqKdQEQ", "Expiration Time - Tue May 26 2043 07:43:42 GMT"),
+                arguments("UTC","eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoiMjMxNjIzOTAyMiJ9.kDOLZJTcFVwrSVSDeFK31EIx7Q4e4Ya33iNCk4QZ10c", "Expiration Time - Tue May 26 2043 07:43:42 GMT"),
+                arguments("UTC","eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoiMjAzNi0xMi0xOVQxNjozOTo1Ny0wODowMCJ9.", "Expiration Time - Sat Dec 20 2036 00:39:57 GMT"),
+                arguments("America/Los_Angeles","eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoyMzE2MjM5MDIyfQ.nmCDcUHT-yLgrRG1LKMH9E2FQs2xWcB8CncxoqKdQEQ", "Expiration Time - Tue May 26 2043 00:43:42 GMT-7"),
+                arguments("America/Los_Angeles","eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoiMjMxNjIzOTAyMiJ9.kDOLZJTcFVwrSVSDeFK31EIx7Q4e4Ya33iNCk4QZ10c", "Expiration Time - Tue May 26 2043 00:43:42 GMT-7"),
+                arguments("America/Los_Angeles","eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoiMjAzNi0xMi0xOVQxNjozOTo1Ny0wODowMCJ9.", "Expiration Time - Fri Dec 19 2036 16:39:57 GMT-8"),
+                arguments("Asia/Seoul","eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoyMzE2MjM5MDIyfQ.nmCDcUHT-yLgrRG1LKMH9E2FQs2xWcB8CncxoqKdQEQ", "Expiration Time - Tue May 26 2043 16:43:42 GMT+9"),
+                arguments("Asia/Seoul","eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoiMjMxNjIzOTAyMiJ9.kDOLZJTcFVwrSVSDeFK31EIx7Q4e4Ya33iNCk4QZ10c", "Expiration Time - Tue May 26 2043 16:43:42 GMT+9"),
+                arguments("Asia/Seoul","eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiZXhwIjoiMjAzNi0xMi0xOVQxNjozOTo1Ny0wODowMCJ9.", "Expiration Time - Sat Dec 20 2036 09:39:57 GMT+9")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("timeZonesAndJWSWithValidExpValues")
+    void givenJWSWithExpTimeClaims_whenExpiryDateInTheFuture_thenInformationAndTimeZoneCorrect(String timeZone, String data, String expectedText) throws ParseException {
+        JWS jws = JWSFactory.parse(data);
+
+        Information information = jws.information(ZoneId.of(timeZone)).getFirst();
+
+        assertThat(information.text()).isEqualTo(expectedText);
+        assertThat(information.isWarning()).isFalse();
     }
 
     @Test
     void givenJWE_thenInformationIsEmpty() throws ParseException {
         JWE jwe = JWEFactory.parse("eyJlbmMiOiJBMTI4R0NNIiwiYWxnIjoiQTEyOEtXIn0.H3X6mT5HLgcFfzLoe4ku6Knhh9Ofv1eL.qF5-N_7K8VQ4yMSz.WXUNY6eg5fR4tc8Hqf5XDRM9ALGwcQyYG4IYwwg8Ctkx1UuxoV7t6UnemjzCj2sOYUqi3KYpDzrKVJpzokz0vcIem4lFe5N_ds8FAMpW0GSF9ePA8qvV99WaP0N2ECVPmgihvL6qwNhdptlLKtxcOpE41U5LnU22voPK55VF4_1j0WmTgWgZ7DwLDysp6EIDjrrt-DY.febBmP71KADmKRVfeSnv_g");
 
-        assertThat(jwe.information()).isEmpty();
+        assertThat(jwe.information(ZoneId.of("UTC"))).isEmpty();
     }
 }

--- a/src/test/java/com/blackberry/jwteditor/model/jose/TimeClaimTest.java
+++ b/src/test/java/com/blackberry/jwteditor/model/jose/TimeClaimTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.stream.Stream;
 
 import static com.blackberry.jwteditor.model.jose.TimeClaimType.*;
@@ -32,7 +33,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class TimeClaimTest {
-
     @EnumSource(TimeClaimType.class)
     @ParameterizedTest
     void invalidEpochTime(TimeClaimType type) {
@@ -42,7 +42,7 @@ class TimeClaimTest {
         assertThat(timeClaim.value()).isEqualTo("-1");
         assertThat(timeClaim.isValid()).isFalse();
         assertThat(timeClaim.hasDate()).isFalse();
-        assertThat(timeClaim.date()).isEmpty();
+        assertThat(timeClaim.date(ZoneId.of("UTC"))).isEmpty();
         assertThat(timeClaim.dateTime()).isNull();
     }
 
@@ -55,14 +55,14 @@ class TimeClaimTest {
         assertThat(timeClaim.value()).isEqualTo("invalid");
         assertThat(timeClaim.isValid()).isFalse();
         assertThat(timeClaim.hasDate()).isFalse();
-        assertThat(timeClaim.date()).isEmpty();
+        assertThat(timeClaim.date(ZoneId.of("UTC"))).isEmpty();
         assertThat(timeClaim.dateTime()).isNull();
     }
 
     static Stream<Arguments> isoDateTimes() {
         return Stream.of(
-                arguments("1985-04-12T23:20:50.52Z", "Fri Apr 12 1985 23:20:50"),
-                arguments("1996-12-19T16:39:57-08:00", "Thu Dec 19 1996 16:39:57")
+                arguments("1985-04-12T23:20:50.52Z", "Fri Apr 12 1985 23:20:50 GMT"),
+                arguments("1996-12-19T16:39:57-08:00", "Fri Dec 20 1996 00:39:57 GMT")
         );
     }
 
@@ -76,14 +76,14 @@ class TimeClaimTest {
         assertThat(timeClaim.value()).isEqualTo(isoDateTime);
         assertThat(timeClaim.isValid()).isTrue();
         assertThat(timeClaim.hasDate()).isTrue();
-        assertThat(timeClaim.date()).isEqualTo(expectedDateTimeString);
+        assertThat(timeClaim.date(ZoneId.of("UTC"))).isEqualTo(expectedDateTimeString);
         assertThat(timeClaim.dateTime()).isNotNull();
     }
 
     static Stream<Arguments> epochDateTimes() {
         return Stream.of(
-                arguments(482196050L, "Fri Apr 12 1985 23:20:50"),
-                arguments(851042397L, "Fri Dec 20 1996 00:39:57")
+                arguments(482196050L, "Fri Apr 12 1985 23:20:50 GMT"),
+                arguments(851042397L, "Fri Dec 20 1996 00:39:57 GMT")
         );
     }
 
@@ -98,7 +98,7 @@ class TimeClaimTest {
         assertThat(timeClaim.value()).isEqualTo(epochDateTimeValue);
         assertThat(timeClaim.isValid()).isTrue();
         assertThat(timeClaim.hasDate()).isTrue();
-        assertThat(timeClaim.date()).isEqualTo(expectedDateTimeString);
+        assertThat(timeClaim.date(ZoneId.of("UTC"))).isEqualTo(expectedDateTimeString);
         assertThat(timeClaim.dateTime()).isNotNull();
     }
 
@@ -113,7 +113,7 @@ class TimeClaimTest {
         assertThat(timeClaim.value()).isEqualTo(epochSecondsValue);
         assertThat(timeClaim.isValid()).isFalse();
         assertThat(timeClaim.hasDate()).isTrue();
-        assertThat(timeClaim.date()).isNotEmpty();
+        assertThat(timeClaim.date(ZoneId.of("UTC"))).isNotEmpty();
         assertThat(timeClaim.dateTime()).isNotNull();
     }
 
@@ -128,7 +128,7 @@ class TimeClaimTest {
         assertThat(timeClaim.value()).isEqualTo(epochSecondsValue);
         assertThat(timeClaim.isValid()).isTrue();
         assertThat(timeClaim.hasDate()).isTrue();
-        assertThat(timeClaim.date()).isNotEmpty();
+        assertThat(timeClaim.date(ZoneId.of("UTC"))).isNotEmpty();
         assertThat(timeClaim.dateTime()).isNotNull();
     }
 
@@ -143,7 +143,7 @@ class TimeClaimTest {
         assertThat(timeClaim.value()).isEqualTo(epochSecondsValue);
         assertThat(timeClaim.isValid()).isTrue();
         assertThat(timeClaim.hasDate()).isTrue();
-        assertThat(timeClaim.date()).isNotEmpty();
+        assertThat(timeClaim.date(ZoneId.of("UTC"))).isNotEmpty();
         assertThat(timeClaim.dateTime()).isNotNull();
     }
 
@@ -158,7 +158,7 @@ class TimeClaimTest {
         assertThat(timeClaim.value()).isEqualTo(epochSecondsValue);
         assertThat(timeClaim.isValid()).isFalse();
         assertThat(timeClaim.hasDate()).isTrue();
-        assertThat(timeClaim.date()).isNotEmpty();
+        assertThat(timeClaim.date(ZoneId.of("UTC"))).isNotEmpty();
         assertThat(timeClaim.dateTime()).isNotNull();
     }
     @Test
@@ -172,7 +172,7 @@ class TimeClaimTest {
         assertThat(timeClaim.value()).isEqualTo(epochSecondsValue);
         assertThat(timeClaim.isValid()).isTrue();
         assertThat(timeClaim.hasDate()).isTrue();
-        assertThat(timeClaim.date()).isNotEmpty();
+        assertThat(timeClaim.date(ZoneId.of("UTC"))).isNotEmpty();
         assertThat(timeClaim.dateTime()).isNotNull();
     }
 
@@ -187,7 +187,56 @@ class TimeClaimTest {
         assertThat(timeClaim.value()).isEqualTo(epochSecondsValue);
         assertThat(timeClaim.isValid()).isFalse();
         assertThat(timeClaim.hasDate()).isTrue();
-        assertThat(timeClaim.date()).isNotEmpty();
+        assertThat(timeClaim.date(ZoneId.of("UTC"))).isNotEmpty();
         assertThat(timeClaim.dateTime()).isNotNull();
+    }
+
+    static Stream<Arguments> expectedTimeZoneConversionsFromEpochSeconds() {
+        return Stream.of(
+                arguments("UTC", Long.toString(0L), "Thu Jan 01 1970 00:00:00 GMT"),
+                arguments("UTC", Long.toString(946684800L), "Sat Jan 01 2000 00:00:00 GMT"),
+                arguments("UTC", Long.toString(1751328000), "Tue Jul 01 2025 00:00:00 GMT"),
+                arguments("UTC", Long.toString(2524608000L), "Sat Jan 01 2050 00:00:00 GMT"),
+                arguments("America/Los_Angeles", Long.toString(0L), "Wed Dec 31 1969 16:00:00 GMT-8"),
+                arguments("America/Los_Angeles", Long.toString(946684800L), "Fri Dec 31 1999 16:00:00 GMT-8"),
+                arguments("America/Los_Angeles", Long.toString(1751328000), "Mon Jun 30 2025 17:00:00 GMT-7"),
+                arguments("America/Los_Angeles", Long.toString(2524608000L), "Fri Dec 31 2049 16:00:00 GMT-8"),
+                arguments("Asia/Seoul", Long.toString(0L), "Thu Jan 01 1970 09:00:00 GMT+9"),
+                arguments("Asia/Seoul", Long.toString(946684800L), "Sat Jan 01 2000 09:00:00 GMT+9"),
+                arguments("Asia/Seoul", Long.toString(1751328000), "Tue Jul 01 2025 09:00:00 GMT+9"),
+                arguments("Asia/Seoul", Long.toString(2524608000L), "Sat Jan 01 2050 09:00:00 GMT+9")
+        );
+    }
+
+    @MethodSource("expectedTimeZoneConversionsFromEpochSeconds")
+    @ParameterizedTest
+    void testDateStringTimeZoneFromEpochSeconds(String timeZoneName, String epochSeconds, String expectedString) {
+        TimeClaim iat = TimeClaimFactory.fromEpochSeconds(ISSUED_AT_TIME, epochSeconds);
+
+        assertThat(iat.date(ZoneId.of(timeZoneName))).isEqualTo(expectedString);
+    }
+
+    static Stream<Arguments> expectedTimeZoneConversionsFromIsoDateTime() {
+        return Stream.of(
+                arguments("UTC", "1970-01-01T00:00:00.00Z", "Thu Jan 01 1970 00:00:00 GMT"),
+                arguments("UTC", "1999-12-31T16:00:00.00-08:00", "Sat Jan 01 2000 00:00:00 GMT"),
+                arguments("UTC", "2025-07-01T02:00:00.00+02:00", "Tue Jul 01 2025 00:00:00 GMT"),
+                arguments("UTC", "2050-01-01T09:00:00.00+09:00", "Sat Jan 01 2050 00:00:00 GMT"),
+                arguments("America/Los_Angeles", "1970-01-01T00:00:00.00Z", "Wed Dec 31 1969 16:00:00 GMT-8"),
+                arguments("America/Los_Angeles", "1999-12-31T16:00:00.00-08:00", "Fri Dec 31 1999 16:00:00 GMT-8"),
+                arguments("America/Los_Angeles", "2025-07-01T02:00:00.00+02:00", "Mon Jun 30 2025 17:00:00 GMT-7"),
+                arguments("America/Los_Angeles", "2050-01-01T09:00:00.00+09:00", "Fri Dec 31 2049 16:00:00 GMT-8"),
+                arguments("Asia/Seoul", "1970-01-01T00:00:00.00Z", "Thu Jan 01 1970 09:00:00 GMT+9"),
+                arguments("Asia/Seoul", "1999-12-31T16:00:00.00-08:00", "Sat Jan 01 2000 09:00:00 GMT+9"),
+                arguments("Asia/Seoul", "2025-07-01T02:00:00.00+02:00", "Tue Jul 01 2025 09:00:00 GMT+9"),
+                arguments("Asia/Seoul", "2050-01-01T09:00:00.00+09:00", "Sat Jan 01 2050 09:00:00 GMT+9")
+        );
+    }
+
+    @MethodSource("expectedTimeZoneConversionsFromIsoDateTime")
+    @ParameterizedTest
+    void testDateStringTimeZoneFromIsoDateTime(String timeZoneName, String isoDateTime, String expectedString) {
+        TimeClaim iat = TimeClaimFactory.fromIsoDateTime(ISSUED_AT_TIME, isoDateTime);
+        assertThat(iat.date(ZoneId.of(timeZoneName))).isEqualTo(expectedString);
     }
 }

--- a/src/test/java/com/blackberry/jwteditor/presenter/InformationTest.java
+++ b/src/test/java/com/blackberry/jwteditor/presenter/InformationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.time.ZoneId;
 import java.util.stream.Stream;
 
 import static com.blackberry.jwteditor.model.jose.TimeClaimType.*;
@@ -32,24 +33,45 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class InformationTest {
-
     static Stream<Arguments> data() {
         return Stream.of(
                 arguments(new TimeClaim(ISSUED_AT_TIME, "isogeny", null), "Issued At - invalid value: isogeny", true),
-                arguments(TimeClaimFactory.fromEpochSeconds(ISSUED_AT_TIME, "1516239022"), "Issued At - Thu Jan 18 2018 01:30:22", false),
-                arguments(TimeClaimFactory.fromEpochSeconds(ISSUED_AT_TIME, "2516239022"), "Issued At - Sun Sep 26 2049 03:17:02", true),
+                arguments(TimeClaimFactory.fromEpochSeconds(ISSUED_AT_TIME, "1516239022"), "Issued At - Thu Jan 18 2018 01:30:22 GMT", false),
+                arguments(TimeClaimFactory.fromEpochSeconds(ISSUED_AT_TIME, "2516239022"), "Issued At - Sun Sep 26 2049 03:17:02 GMT", true),
                 arguments(new TimeClaim(NOT_BEFORE_TIME, "isogeny", null), "Not Before - invalid value: isogeny", true),
-                arguments(TimeClaimFactory.fromEpochSeconds(NOT_BEFORE_TIME, "1516239022"), "Not Before - Thu Jan 18 2018 01:30:22", false),
-                arguments(TimeClaimFactory.fromEpochSeconds(NOT_BEFORE_TIME, "2516239022"), "Not Before - Sun Sep 26 2049 03:17:02", true),
+                arguments(TimeClaimFactory.fromEpochSeconds(NOT_BEFORE_TIME, "1516239022"), "Not Before - Thu Jan 18 2018 01:30:22 GMT", false),
+                arguments(TimeClaimFactory.fromEpochSeconds(NOT_BEFORE_TIME, "2516239022"), "Not Before - Sun Sep 26 2049 03:17:02 GMT", true),
                 arguments(new TimeClaim(EXPIRATION_TIME, "isogeny", null), "Expiration Time - invalid value: isogeny", true),
-                arguments(TimeClaimFactory.fromEpochSeconds(EXPIRATION_TIME, "1516239022"), "Expiration Time - Thu Jan 18 2018 01:30:22", true),
-                arguments(TimeClaimFactory.fromEpochSeconds(EXPIRATION_TIME, "2516239022"), "Expiration Time - Sun Sep 26 2049 03:17:02", false));
+                arguments(TimeClaimFactory.fromEpochSeconds(EXPIRATION_TIME, "1516239022"), "Expiration Time - Thu Jan 18 2018 01:30:22 GMT", true),
+                arguments(TimeClaimFactory.fromEpochSeconds(EXPIRATION_TIME, "2516239022"), "Expiration Time - Sun Sep 26 2049 03:17:02 GMT", false));
     }
 
     @MethodSource("data")
     @ParameterizedTest
     void testInformationFromTimeClaims(TimeClaim timeClaim, String expectedText, boolean expectedIsWarning) {
-        Information information = Information.from(timeClaim);
+        Information information = Information.from(timeClaim, ZoneId.of("UTC"));
+
+        assertThat(information.text()).isEqualTo(expectedText);
+        assertThat(information.isWarning()).isEqualTo(expectedIsWarning);
+    }
+
+    static Stream<Arguments> dataWithTimeZone() {
+        return Stream.of(
+                arguments(new TimeClaim(ISSUED_AT_TIME, "isogeny", null), "Issued At - invalid value: isogeny", true),
+                arguments(TimeClaimFactory.fromEpochSeconds(ISSUED_AT_TIME, "1516239022"), "Issued At - Thu Jan 18 2018 10:30:22 GMT+9", false),
+                arguments(TimeClaimFactory.fromEpochSeconds(ISSUED_AT_TIME, "2516239022"), "Issued At - Sun Sep 26 2049 12:17:02 GMT+9", true),
+                arguments(new TimeClaim(NOT_BEFORE_TIME, "isogeny", null), "Not Before - invalid value: isogeny", true),
+                arguments(TimeClaimFactory.fromEpochSeconds(NOT_BEFORE_TIME, "1516239022"), "Not Before - Thu Jan 18 2018 10:30:22 GMT+9", false),
+                arguments(TimeClaimFactory.fromEpochSeconds(NOT_BEFORE_TIME, "2516239022"), "Not Before - Sun Sep 26 2049 12:17:02 GMT+9", true),
+                arguments(new TimeClaim(EXPIRATION_TIME, "isogeny", null), "Expiration Time - invalid value: isogeny", true),
+                arguments(TimeClaimFactory.fromEpochSeconds(EXPIRATION_TIME, "1516239022"), "Expiration Time - Thu Jan 18 2018 10:30:22 GMT+9", true),
+                arguments(TimeClaimFactory.fromEpochSeconds(EXPIRATION_TIME, "2516239022"), "Expiration Time - Sun Sep 26 2049 12:17:02 GMT+9", false));
+    }
+
+    @MethodSource("dataWithTimeZone")
+    @ParameterizedTest
+    void testInformationFromTimeClaimsWithTimeZone(TimeClaim timeClaim, String expectedText, boolean expectedIsWarning) {
+        Information information = Information.from(timeClaim, ZoneId.of("Asia/Seoul"));
 
         assertThat(information.text()).isEqualTo(expectedText);
         assertThat(information.isWarning()).isEqualTo(expectedIsWarning);


### PR DESCRIPTION
### Description
Currently, time claims shown in the Information Panel in Burp are parsed in whatever time zone they are imported as.
If parsed from epoch times, they're in UTC.
If parsed from IsoDateTime strings, they're in the supplied time zone.

However, this is:
1. inconsistent 
2. generally UTC might be confusing as currently there is no information whatsoever which time zone is used.

With this PR, any string conversion of a TimeClaim object now needs to explicitly define the time zone, and the stringified versions of those timestamp are converted to the defined time zone.

The time zone used is usually the default JVM time zone (excluding unit tests), and the time zone is now explicitly shown to the user like this.

Before:
<img width="402" alt="Screenshot showing the current behavior of the Information Panel of the JWT Editor extension in Burp Suite" src="https://github.com/user-attachments/assets/9cb70c8f-4f43-47ce-be22-a9dcfb18831e" />

After:
<img width="402" alt="Screenshot showing the change in the Information Panel of the JWT Editor extension in Burp Suite" src="https://github.com/user-attachments/assets/0de66443-4593-438d-ab1a-a1c92ecaf07d" />

For the unit tests, the default JVM time is not used to avoid changing it constantly in the JVM (which sounds like a bad practice). Thus, the existing tests were converted to UTC, while some new tests were added to test the time zone support. These tests should also catch the IsoDateTime inconsistencies.

### Related Issue
None.

### How Has This Been Tested?
- Added Unit Tests
- Did a practice test by loading the Extension into Burp and going to a website with a simple JWT
- Adjusted time zones while running Burp to test JVM behavior what happens if the OS time zone changes before making `JVM_DEFAULT_TIME_ZONE_ID` a `static` value (apparently nothing, JVM keeps the old timezone cached, that's why I made it `static`)

### Checklist
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have added appropriate tests for my fix or feature.
- [x] All tests pass locally.
- [x] Checkstyle passes successfully.
- [x] I have made appropriate changes to the documentation.

### Additional Information
None.